### PR TITLE
Allow parsing token accounts as json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2633,6 +2633,8 @@ dependencies = [
  "serde_json",
  "solana-rpc-client-api",
  "solana-sdk",
+ "spl-token",
+ "spl-token-2022 5.0.2",
  "zstd 0.11.2+zstd.1.5.2",
 ]
 

--- a/accounts_on_demand/src/accounts_on_demand.rs
+++ b/accounts_on_demand/src/accounts_on_demand.rs
@@ -139,9 +139,9 @@ impl AccountStorageInterface for AccountsOnDemand {
         // it will first compare with existing filters and do the necessary if needed
         if self.mutable_filters.contains_filter(&account_filter) {
             self.accounts_storage
-                .get_program_accounts(program_id, filters.clone(), commitment)
+                .get_program_accounts(program_id, filters, commitment)
         } else {
-            // subsribing to new gpa accounts
+            // subscribing to new gpa accounts
             let mut lk = self.gpa_in_loading.lock().unwrap();
             match lk
                 .get(&(program_id, filters.clone().unwrap_or_default()))
@@ -149,11 +149,9 @@ impl AccountStorageInterface for AccountsOnDemand {
             {
                 Some(loading_account) => {
                     match loading_account.wait_timeout(lk, Duration::from_secs(10)) {
-                        Ok(_) => self.accounts_storage.get_program_accounts(
-                            program_id,
-                            filters.clone(),
-                            commitment,
-                        ),
+                        Ok(_) => self
+                            .accounts_storage
+                            .get_program_accounts(program_id, filters, commitment),
                         Err(_timeout) => {
                             // todo replace with error
                             log::error!("gPA on program : {}", program_id.to_string());

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -4,14 +4,16 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-solana-sdk = {workspace = true}
-solana-rpc-client-api = {workspace = true}
-itertools = {workspace = true}
-lz4 = {workspace = true}
-zstd = {workspace = true}
-serde = {workspace = true}
-serde_json = {workspace = true}
-bs58 = {workspace = true}
-base64 = {workspace = true}
-anyhow = {workspace = true}
-log = {workspace = true}
+solana-sdk = { workspace = true }
+solana-rpc-client-api = { workspace = true }
+spl-token = { workspace = true }
+spl-token-2022 = { workspace = true }
+itertools = { workspace = true }
+lz4 = { workspace = true }
+zstd = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+bs58 = { workspace = true }
+base64 = { workspace = true }
+anyhow = { workspace = true }
+log = { workspace = true }

--- a/common/src/account_store_interface.rs
+++ b/common/src/account_store_interface.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use std::ops::{Deref, DerefMut};
+
 use crate::account_data::AccountData;
 use crate::account_filter::AccountFilterType;
 use crate::commitment::Commitment;
@@ -28,7 +31,7 @@ impl std::fmt::Display for AccountLoadingError {
 impl std::error::Error for AccountLoadingError {}
 
 pub trait AccountStorageInterface: Send + Sync {
-    // Update account and return true if the account was sucessfylly updated
+    // Update account and return true if the account was successfully updated
     fn update_account(&self, account_data: AccountData, commitment: Commitment) -> bool;
 
     fn initialize_or_update_account(&self, account_data: AccountData);
@@ -42,7 +45,7 @@ pub trait AccountStorageInterface: Send + Sync {
     fn get_program_accounts(
         &self,
         program_pubkey: Pubkey,
-        account_filter: Option<Vec<AccountFilterType>>,
+        account_filters: Option<Vec<AccountFilterType>>,
         commitment: Commitment,
     ) -> Result<Vec<AccountData>, AccountLoadingError>;
 
@@ -56,4 +59,89 @@ pub trait AccountStorageInterface: Send + Sync {
         program_id: Pubkey,
         snapshot: Vec<u8>,
     ) -> Result<(), AccountLoadingError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TokenProgramType {
+    TokenProgram,
+    Token2022Program,
+}
+
+impl AsRef<Pubkey> for TokenProgramType {
+    fn as_ref(&self) -> &Pubkey {
+        match self {
+            TokenProgramType::TokenProgram => &spl_token::ID,
+            TokenProgramType::Token2022Program => &spl_token_2022::ID,
+        }
+    }
+}
+
+impl TryFrom<&Pubkey> for TokenProgramType {
+    type Error = ();
+
+    fn try_from(value: &Pubkey) -> Result<Self, Self::Error> {
+        if *value == spl_token::ID {
+            Ok(TokenProgramType::TokenProgram)
+        } else if *value == spl_token_2022::ID {
+            Ok(TokenProgramType::Token2022Program)
+        } else {
+            Err(())
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TokenProgramAccountData {
+    TokenAccount(TokenProgramTokenAccountData),
+    OtherAccount(AccountData),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TokenProgramTokenAccountData {
+    pub account_data: AccountData,
+    pub mint_pubkey: Pubkey,
+}
+
+impl TokenProgramAccountData {
+    pub fn into_inner(self) -> AccountData {
+        match self {
+            TokenProgramAccountData::TokenAccount(token_account) => token_account.account_data,
+            TokenProgramAccountData::OtherAccount(account_data) => account_data,
+        }
+    }
+}
+
+impl Deref for TokenProgramAccountData {
+    type Target = AccountData;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            TokenProgramAccountData::TokenAccount(token_account) => &token_account.account_data,
+            TokenProgramAccountData::OtherAccount(account_data) => account_data,
+        }
+    }
+}
+
+impl DerefMut for TokenProgramAccountData {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            TokenProgramAccountData::TokenAccount(token_account) => &mut token_account.account_data,
+            TokenProgramAccountData::OtherAccount(account_data) => account_data,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Mint {
+    TokenMint(spl_token::state::Mint),
+    Token2022Mint(spl_token_2022::state::Mint),
+}
+
+pub trait ProgramAccountStorageInterface: Send + Sync {
+    fn get_program_accounts_with_mints(
+        &self,
+        token_program_type: TokenProgramType,
+        account_filters: Option<Vec<AccountFilterType>>,
+        commitment: Commitment,
+    ) -> Result<(Vec<TokenProgramAccountData>, HashMap<Pubkey, Mint>), AccountLoadingError>;
 }

--- a/common/src/account_store_interface.rs
+++ b/common/src/account_store_interface.rs
@@ -144,4 +144,10 @@ pub trait ProgramAccountStorageInterface: Send + Sync {
         account_filters: Option<Vec<AccountFilterType>>,
         commitment: Commitment,
     ) -> Result<(Vec<TokenProgramAccountData>, HashMap<Pubkey, Mint>), AccountLoadingError>;
+
+    fn get_account_with_mint(
+        &self,
+        account_pk: Pubkey,
+        commitment: Commitment,
+    ) -> Result<Option<(TokenProgramAccountData, Option<Mint>)>, AccountLoadingError>;
 }

--- a/simulate_from_snapshot/src/main_accountsdb.rs
+++ b/simulate_from_snapshot/src/main_accountsdb.rs
@@ -74,7 +74,7 @@ async fn main() {
     process_slot_updates(db.clone(), slots_rx);
     start_backfill(slot.info.slot, db.clone());
 
-    let rpc_server = RpcServerImpl::new(db.clone());
+    let rpc_server = RpcServerImpl::new(db.clone(), None);
 
     info!("Storage Initialized with snapshot");
     let jh = RpcServerImpl::start_serving(rpc_server, 10700)

--- a/simulate_from_snapshot/src/main_tokenstorage.rs
+++ b/simulate_from_snapshot/src/main_tokenstorage.rs
@@ -36,7 +36,7 @@ async fn main() {
     } = args;
 
     let token_account_storage = Arc::new(InmemoryTokenAccountStorage::default());
-    let token_storage: Arc<dyn AccountStorageInterface> =
+    let token_storage: Arc<TokenProgramAccountsStorage> =
         Arc::new(TokenProgramAccountsStorage::new(token_account_storage));
 
     // fill from quic geyser stream
@@ -145,7 +145,7 @@ async fn main() {
             write_version: 0,
         });
         cnt += 1;
-        if cnt % 100000 == 0 {
+        if cnt % 100_000 == 0 {
             log::info!("{} token accounts loaded", cnt);
         }
     }
@@ -155,7 +155,7 @@ async fn main() {
         "Storage Initialized with snapshot, {} token accounts loaded",
         cnt
     );
-    let rpc_server = RpcServerImpl::new(token_storage);
+    let rpc_server = RpcServerImpl::new(token_storage.clone(), Some(token_storage));
     let jh = RpcServerImpl::start_serving(rpc_server, 10700)
         .await
         .unwrap();

--- a/token_account_storage/src/account_types.rs
+++ b/token_account_storage/src/account_types.rs
@@ -1,3 +1,4 @@
+use lite_account_manager_common::account_store_interface::TokenProgramType;
 use serde::{Deserialize, Serialize};
 use solana_sdk::pubkey::Pubkey;
 
@@ -9,6 +10,15 @@ pub type TokenAccountIndex = u32;
 pub enum Program {
     TokenProgram,
     Token2022Program,
+}
+
+impl From<TokenProgramType> for Program {
+    fn from(value: TokenProgramType) -> Self {
+        match value {
+            TokenProgramType::TokenProgram => Self::TokenProgram,
+            TokenProgramType::Token2022Program => Self::Token2022Program,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/token_account_storage/src/inmemory_token_storage.rs
+++ b/token_account_storage/src/inmemory_token_storage.rs
@@ -596,7 +596,7 @@ impl TokenProgramAccountsStorage {
                                             mint_pubkey: mint_account.pubkey,
                                         },
                                     ));
-                                    if mints.contains_key(&mint_account.pubkey) {
+                                    if !mints.contains_key(&mint_account.pubkey) {
                                         mints.insert(mint_account.pubkey, mint_account.clone());
                                     }
                                 }


### PR DESCRIPTION
Add an optional DB trait that offers a specialized gpa method allowing easier json serialization of token accounts.

The new trait offers a method that returns token account data with a mint pubkey and a hash of deserialized mint accounts for the queried token accounts that are necessary to correctly serialize token accounts in json format.