### PR TITLE
Fix panic while catching up to cluster

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ members = [
 ]
 
 [workspace.package]
-name = "solana-lite-account-manager"
 version = "0.1.0"
 edition = "2021"
 authors = ["gmgalactus <gmgalactus@mango.markets>"]

--- a/account_storage/src/accountsdb/accounts_db.rs
+++ b/account_storage/src/accountsdb/accounts_db.rs
@@ -276,7 +276,7 @@ impl AccountStorageInterface for AccountsDb {
         Ok(result)
     }
 
-    fn process_slot_data(&self, info: SlotInfo, commitment: Commitment) -> Vec<AccountData> {
+    fn process_slot_data(&self, info: SlotInfo, commitment: Commitment) -> Vec<()> {
         let slot = info.slot;
         if commitment == Commitment::Finalized {
             self.accounts.add_root(slot);
@@ -321,7 +321,9 @@ impl AccountStorageInterface for AccountsDb {
             .into_iter()
             .filter(|(_, _, updated_slot)| *updated_slot == slot)
             .map(|(key, data, slot)| Self::convert_to_account_data(key, slot, data))
-            .collect_vec()
+            .collect_vec();
+
+        todo!()
     }
 
     fn create_snapshot(&self, _program_id: Pubkey) -> Result<Vec<u8>, AccountLoadingError> {

--- a/accounts_on_demand/src/accounts_on_demand.rs
+++ b/accounts_on_demand/src/accounts_on_demand.rs
@@ -193,7 +193,7 @@ impl AccountStorageInterface for AccountsOnDemand {
         }
     }
 
-    fn process_slot_data(&self, slot_info: SlotInfo, commitment: Commitment) -> Vec<AccountData> {
+    fn process_slot_data(&self, slot_info: SlotInfo, commitment: Commitment) -> Vec<()> {
         self.accounts_storage
             .process_slot_data(slot_info, commitment)
     }

--- a/accounts_on_demand/src/accounts_on_demand.rs
+++ b/accounts_on_demand/src/accounts_on_demand.rs
@@ -193,9 +193,9 @@ impl AccountStorageInterface for AccountsOnDemand {
         }
     }
 
-    fn process_slot_data(&self, slot_info: SlotInfo, commitment: Commitment) -> Vec<()> {
+    fn process_slot_data(&self, slot_info: SlotInfo, commitment: Commitment) {
         self.accounts_storage
-            .process_slot_data(slot_info, commitment)
+            .process_slot_data(slot_info, commitment);
     }
 
     fn create_snapshot(&self, program_id: Pubkey) -> Result<Vec<u8>, AccountLoadingError> {

--- a/common/src/account_store_interface.rs
+++ b/common/src/account_store_interface.rs
@@ -49,7 +49,7 @@ pub trait AccountStorageInterface: Send + Sync {
         commitment: Commitment,
     ) -> Result<Vec<AccountData>, AccountLoadingError>;
 
-    fn process_slot_data(&self, slot_info: SlotInfo, commitment: Commitment) -> Vec<AccountData>;
+    fn process_slot_data(&self, slot_info: SlotInfo, commitment: Commitment) -> Vec<()>;
 
     // snapshot should always be created at finalized slot
     fn create_snapshot(&self, program_id: Pubkey) -> Result<Vec<u8>, AccountLoadingError>;

--- a/common/src/account_store_interface.rs
+++ b/common/src/account_store_interface.rs
@@ -49,7 +49,7 @@ pub trait AccountStorageInterface: Send + Sync {
         commitment: Commitment,
     ) -> Result<Vec<AccountData>, AccountLoadingError>;
 
-    fn process_slot_data(&self, slot_info: SlotInfo, commitment: Commitment) -> Vec<()>;
+    fn process_slot_data(&self, slot_info: SlotInfo, commitment: Commitment);
 
     // snapshot should always be created at finalized slot
     fn create_snapshot(&self, program_id: Pubkey) -> Result<Vec<u8>, AccountLoadingError>;

--- a/simulate_from_snapshot/src/rpc_server.rs
+++ b/simulate_from_snapshot/src/rpc_server.rs
@@ -74,7 +74,7 @@ impl RpcServerImpl {
 
         let http_server_handle = ServerBuilder::default()
             .set_middleware(middleware)
-            .max_connections(10)
+            .max_connections(10_000)
             .max_request_body_size(1024 * 1024) // 16 MB
             .max_response_body_size(512 * 1024 * 1024) // 512 MBs
             .http_only()

--- a/token_account_storage/src/inmemory_token_storage.rs
+++ b/token_account_storage/src/inmemory_token_storage.rs
@@ -862,7 +862,7 @@ impl AccountStorageInterface for TokenProgramAccountsStorage {
             })
     }
 
-    fn process_slot_data(&self, slot_info: SlotInfo, commitment: Commitment) -> Vec<AccountData> {
+    fn process_slot_data(&self, slot_info: SlotInfo, commitment: Commitment) -> Vec<()> {
         match commitment {
             Commitment::Processed => {
                 log::debug!("process slot data  : {slot_info:?}");
@@ -876,7 +876,8 @@ impl AccountStorageInterface for TokenProgramAccountsStorage {
                     self.processed_storage.update_slot_info(slot_info);
                 }
                 self.processed_storage
-                    .get_processed_for_slot(slot_info, &self.mints_by_index)
+                    .get_processed_for_slot(slot_info, &self.mints_by_index);
+                todo!()
             }
             Commitment::Finalized => {
                 log::debug!("finalize slot data  : {slot_info:?}");
@@ -902,7 +903,7 @@ impl AccountStorageInterface for TokenProgramAccountsStorage {
                 for (finalized_account, _) in finalized_accounts {
                     self.add_account_finalized(finalized_account.processed_account);
                 }
-                accounts_notifications
+                vec![]
             }
         }
     }

--- a/token_account_storage/tests/token_program_gpa_tests.rs
+++ b/token_account_storage/tests/token_program_gpa_tests.rs
@@ -8,9 +8,12 @@ use solana_sdk::pubkey::Pubkey;
 mod utils;
 
 use lite_account_manager_common::{
-    account_filter::{AccountFilterType, MemcmpFilter},
+    account_filter::{AccountFilterType, MemcmpFilter, MemcmpFilterData},
     account_store_interface::AccountStorageInterface,
     commitment::Commitment,
+};
+use utils::{
+    create_mint_account_data, create_token_account_data, MintCreationParams, TokenAccountParams,
 };
 
 #[test]
@@ -19,12 +22,12 @@ pub fn test_gpa_token_account() {
     let token_store = TokenProgramAccountsStorage::new(inmemory_token_storage);
 
     let mint_1: Pubkey = Pubkey::new_unique();
-    let mint_creation_params = utils::MintCreationParams::create_default(100);
-    let mint_account_1 = utils::create_mint_account_data(mint_1, mint_creation_params, 0, 0);
+    let mint_creation_params = MintCreationParams::create_default(100);
+    let mint_account_1 = create_mint_account_data(mint_1, mint_creation_params, 0, 0);
 
     let mint_2: Pubkey = Pubkey::new_unique();
-    let mint_creation_params = utils::MintCreationParams::create_default(100);
-    let mint_account_2 = utils::create_mint_account_data(mint_2, mint_creation_params, 0, 0);
+    let mint_creation_params = MintCreationParams::create_default(100);
+    let mint_account_2 = create_mint_account_data(mint_2, mint_creation_params, 0, 0);
 
     let owner_1 = Pubkey::new_unique();
     let owner_2 = Pubkey::new_unique();
@@ -33,27 +36,27 @@ pub fn test_gpa_token_account() {
     let token_acc_1_1 = Pubkey::new_unique();
     let token_acc_1_2 = Pubkey::new_unique();
     let token_acc_1_3 = Pubkey::new_unique();
-    let token_acc_1_1_params = utils::TokenAccountParams::create_default(owner_1, mint_1, 100);
-    let token_acc_1_2_params = utils::TokenAccountParams::create_default(owner_1, mint_2, 200);
-    let token_acc_1_3_params = utils::TokenAccountParams::create_default(owner_1, mint_2, 300);
+    let token_acc_1_1_params = TokenAccountParams::create_default(owner_1, mint_1, 100);
+    let token_acc_1_2_params = TokenAccountParams::create_default(owner_1, mint_2, 200);
+    let token_acc_1_3_params = TokenAccountParams::create_default(owner_1, mint_2, 300);
     let token_acc_1_1_account =
-        utils::create_token_account_data(token_acc_1_1, token_acc_1_1_params, 0, 0);
+        create_token_account_data(token_acc_1_1, token_acc_1_1_params, 0, 0);
     let token_acc_1_2_account =
-        utils::create_token_account_data(token_acc_1_2, token_acc_1_2_params, 0, 0);
+        create_token_account_data(token_acc_1_2, token_acc_1_2_params, 0, 0);
     let token_acc_1_3_account =
-        utils::create_token_account_data(token_acc_1_3, token_acc_1_3_params, 0, 0);
+        create_token_account_data(token_acc_1_3, token_acc_1_3_params, 0, 0);
     token_store.initialize_or_update_account(token_acc_1_1_account.clone());
     token_store.initialize_or_update_account(token_acc_1_2_account.clone());
     token_store.initialize_or_update_account(token_acc_1_3_account.clone());
 
     let token_acc_2_1 = Pubkey::new_unique();
     let token_acc_2_2 = Pubkey::new_unique();
-    let token_acc_2_1_params = utils::TokenAccountParams::create_default(owner_2, mint_1, 400);
-    let token_acc_2_2_params = utils::TokenAccountParams::create_default(owner_2, mint_1, 500);
+    let token_acc_2_1_params = TokenAccountParams::create_default(owner_2, mint_1, 400);
+    let token_acc_2_2_params = TokenAccountParams::create_default(owner_2, mint_1, 500);
     let token_acc_2_1_account =
-        utils::create_token_account_data(token_acc_2_1, token_acc_2_1_params, 0, 0);
+        create_token_account_data(token_acc_2_1, token_acc_2_1_params, 0, 0);
     let token_acc_2_2_account =
-        utils::create_token_account_data(token_acc_2_2, token_acc_2_2_params, 0, 0);
+        create_token_account_data(token_acc_2_2, token_acc_2_2_params, 0, 0);
     token_store.initialize_or_update_account(token_acc_2_1_account.clone());
     token_store.initialize_or_update_account(token_acc_2_2_account.clone());
 
@@ -62,21 +65,21 @@ pub fn test_gpa_token_account() {
     let token_acc_3_3 = Pubkey::new_unique();
     let token_acc_3_4 = Pubkey::new_unique();
     let token_acc_3_5 = Pubkey::new_unique();
-    let token_acc_3_1_params = utils::TokenAccountParams::create_default(owner_3, mint_1, 600);
-    let token_acc_3_2_params = utils::TokenAccountParams::create_default(owner_3, mint_1, 700);
-    let token_acc_3_3_params = utils::TokenAccountParams::create_default(owner_3, mint_2, 800);
-    let token_acc_3_4_params = utils::TokenAccountParams::create_default(owner_3, mint_2, 900);
-    let token_acc_3_5_params = utils::TokenAccountParams::create_default(owner_3, mint_1, 1000);
+    let token_acc_3_1_params = TokenAccountParams::create_default(owner_3, mint_1, 600);
+    let token_acc_3_2_params = TokenAccountParams::create_default(owner_3, mint_1, 700);
+    let token_acc_3_3_params = TokenAccountParams::create_default(owner_3, mint_2, 800);
+    let token_acc_3_4_params = TokenAccountParams::create_default(owner_3, mint_2, 900);
+    let token_acc_3_5_params = TokenAccountParams::create_default(owner_3, mint_1, 1000);
     let token_acc_3_1_account =
-        utils::create_token_account_data(token_acc_3_1, token_acc_3_1_params, 0, 0);
+        create_token_account_data(token_acc_3_1, token_acc_3_1_params, 0, 0);
     let token_acc_3_2_account =
-        utils::create_token_account_data(token_acc_3_2, token_acc_3_2_params, 0, 0);
+        create_token_account_data(token_acc_3_2, token_acc_3_2_params, 0, 0);
     let token_acc_3_3_account =
-        utils::create_token_account_data(token_acc_3_3, token_acc_3_3_params, 0, 0);
+        create_token_account_data(token_acc_3_3, token_acc_3_3_params, 0, 0);
     let token_acc_3_4_account =
-        utils::create_token_account_data(token_acc_3_4, token_acc_3_4_params, 0, 0);
+        create_token_account_data(token_acc_3_4, token_acc_3_4_params, 0, 0);
     let token_acc_3_5_account =
-        utils::create_token_account_data(token_acc_3_5, token_acc_3_5_params, 0, 0);
+        create_token_account_data(token_acc_3_5, token_acc_3_5_params, 0, 0);
     token_store.initialize_or_update_account(token_acc_3_1_account.clone());
     token_store.initialize_or_update_account(token_acc_3_2_account.clone());
     token_store.initialize_or_update_account(token_acc_3_3_account.clone());
@@ -93,9 +96,7 @@ pub fn test_gpa_token_account() {
                 AccountFilterType::DataSize(165),
                 AccountFilterType::Memcmp(MemcmpFilter {
                     offset: 32,
-                    data: lite_account_manager_common::account_filter::MemcmpFilterData::Bytes(
-                        owner_1.to_bytes().to_vec(),
-                    ),
+                    data: MemcmpFilterData::Bytes(owner_1.to_bytes().to_vec()),
                 }),
             ]),
             Commitment::Processed,
@@ -113,9 +114,7 @@ pub fn test_gpa_token_account() {
                 AccountFilterType::DataSize(165),
                 AccountFilterType::Memcmp(MemcmpFilter {
                     offset: 32,
-                    data: lite_account_manager_common::account_filter::MemcmpFilterData::Bytes(
-                        owner_2.to_bytes().to_vec(),
-                    ),
+                    data: MemcmpFilterData::Bytes(owner_2.to_bytes().to_vec()),
                 }),
             ]),
             Commitment::Processed,
@@ -132,9 +131,7 @@ pub fn test_gpa_token_account() {
                 AccountFilterType::DataSize(165),
                 AccountFilterType::Memcmp(MemcmpFilter {
                     offset: 32,
-                    data: lite_account_manager_common::account_filter::MemcmpFilterData::Bytes(
-                        owner_3.to_bytes().to_vec(),
-                    ),
+                    data: MemcmpFilterData::Bytes(owner_3.to_bytes().to_vec()),
                 }),
             ]),
             Commitment::Processed,
@@ -154,15 +151,11 @@ pub fn test_gpa_token_account() {
                 AccountFilterType::DataSize(165),
                 AccountFilterType::Memcmp(MemcmpFilter {
                     offset: 32,
-                    data: lite_account_manager_common::account_filter::MemcmpFilterData::Bytes(
-                        owner_3.to_bytes().to_vec(),
-                    ),
+                    data: MemcmpFilterData::Bytes(owner_3.to_bytes().to_vec()),
                 }),
                 AccountFilterType::Memcmp(MemcmpFilter {
                     offset: 0,
-                    data: lite_account_manager_common::account_filter::MemcmpFilterData::Bytes(
-                        mint_1.to_bytes().to_vec(),
-                    ),
+                    data: MemcmpFilterData::Bytes(mint_1.to_bytes().to_vec()),
                 }),
             ]),
             Commitment::Processed,
@@ -181,9 +174,7 @@ pub fn test_gpa_token_account() {
                 AccountFilterType::DataSize(165),
                 AccountFilterType::Memcmp(MemcmpFilter {
                     offset: 0,
-                    data: lite_account_manager_common::account_filter::MemcmpFilterData::Bytes(
-                        mint_1.to_bytes().to_vec(),
-                    ),
+                    data: MemcmpFilterData::Bytes(mint_1.to_bytes().to_vec()),
                 }),
             ]),
             Commitment::Confirmed,
@@ -204,9 +195,7 @@ pub fn test_gpa_token_account() {
                 AccountFilterType::DataSize(165),
                 AccountFilterType::Memcmp(MemcmpFilter {
                     offset: 0,
-                    data: lite_account_manager_common::account_filter::MemcmpFilterData::Bytes(
-                        mint_2.to_bytes().to_vec(),
-                    ),
+                    data: MemcmpFilterData::Bytes(mint_2.to_bytes().to_vec()),
                 }),
             ]),
             Commitment::Confirmed,

--- a/token_account_storage/tests/token_program_tests.rs
+++ b/token_account_storage/tests/token_program_tests.rs
@@ -150,17 +150,17 @@ pub fn test_saving_and_loading_token_account() {
         vec![]
     );
 
-    assert_eq!(
-        token_store.process_slot_data(
-            SlotInfo {
-                slot: 3,
-                parent: 2,
-                root: 0,
-            },
-            Commitment::Confirmed
-        ),
-        vec![token_account_data_2.clone()]
-    );
+    // assert_eq!(
+    //     token_store.process_slot_data(
+    //         SlotInfo {
+    //             slot: 3,
+    //             parent: 2,
+    //             root: 0,
+    //         },
+    //         Commitment::Confirmed
+    //     ),
+    //     vec![token_account_data_2.clone()]
+    // );
 
     assert_eq!(
         utils::parse_account_data_to_token_params(
@@ -236,29 +236,29 @@ pub fn test_saving_and_loading_token_account() {
         mint_creation_params
     );
 
-    assert_eq!(
-        token_store.process_slot_data(
-            SlotInfo {
-                slot: 4,
-                parent: 3,
-                root: 0,
-            },
-            Commitment::Confirmed
-        ),
-        vec![account_data_3.clone()]
-    );
+    // assert_eq!(
+    //     token_store.process_slot_data(
+    //         SlotInfo {
+    //             slot: 4,
+    //             parent: 3,
+    //             root: 0,
+    //         },
+    //         Commitment::Confirmed
+    //     ),
+    //     vec![account_data_3.clone()]
+    // );
 
-    assert_eq!(
-        token_store.process_slot_data(
-            SlotInfo {
-                slot: 3,
-                parent: 2,
-                root: 0,
-            },
-            Commitment::Finalized
-        ),
-        vec![token_account_data_2.clone()]
-    );
+    // assert_eq!(
+    //     token_store.process_slot_data(
+    //         SlotInfo {
+    //             slot: 3,
+    //             parent: 2,
+    //             root: 0,
+    //         },
+    //         Commitment::Finalized
+    //     ),
+    //     vec![token_account_data_2.clone()]
+    // );
 
     let mint_2 = utils::MintCreationParams::create_random(&mut rng, 2000);
 
@@ -413,10 +413,10 @@ pub fn test_saving_and_loading_token_account() {
         Commitment::Finalized,
     );
 
-    assert!(
-        accounts_updated == vec![mint_account_2.clone(), account_data_3.clone()]
-            || accounts_updated == vec![account_data_3.clone(), mint_account_2.clone()]
-    );
+    // assert!(
+    //     accounts_updated == vec![mint_account_2.clone(), account_data_3.clone()]
+    //         || accounts_updated == vec![account_data_3.clone(), mint_account_2.clone()]
+    // );
 
     assert_eq!(
         token_store

--- a/token_account_storage/tests/token_program_tests.rs
+++ b/token_account_storage/tests/token_program_tests.rs
@@ -126,41 +126,32 @@ pub fn test_saving_and_loading_token_account() {
         lite_account_manager_common::commitment::Commitment::Processed,
     );
 
-    assert_eq!(
-        token_store.process_slot_data(
-            SlotInfo {
-                slot: 3,
-                parent: 2,
-                root: 0,
-            },
-            Commitment::Processed
-        ),
-        vec![]
+    token_store.process_slot_data(
+        SlotInfo {
+            slot: 3,
+            parent: 2,
+            root: 0,
+        },
+        Commitment::Processed,
     );
 
-    assert_eq!(
-        token_store.process_slot_data(
-            SlotInfo {
-                slot: 4,
-                parent: 3,
-                root: 0,
-            },
-            Commitment::Processed
-        ),
-        vec![]
+    token_store.process_slot_data(
+        SlotInfo {
+            slot: 4,
+            parent: 3,
+            root: 0,
+        },
+        Commitment::Processed,
     );
 
-    // assert_eq!(
-    //     token_store.process_slot_data(
-    //         SlotInfo {
-    //             slot: 3,
-    //             parent: 2,
-    //             root: 0,
-    //         },
-    //         Commitment::Confirmed
-    //     ),
-    //     vec![token_account_data_2.clone()]
-    // );
+    token_store.process_slot_data(
+        SlotInfo {
+            slot: 3,
+            parent: 2,
+            root: 0,
+        },
+        Commitment::Confirmed,
+    );
 
     assert_eq!(
         utils::parse_account_data_to_token_params(
@@ -236,29 +227,23 @@ pub fn test_saving_and_loading_token_account() {
         mint_creation_params
     );
 
-    // assert_eq!(
-    //     token_store.process_slot_data(
-    //         SlotInfo {
-    //             slot: 4,
-    //             parent: 3,
-    //             root: 0,
-    //         },
-    //         Commitment::Confirmed
-    //     ),
-    //     vec![account_data_3.clone()]
-    // );
+    token_store.process_slot_data(
+        SlotInfo {
+            slot: 4,
+            parent: 3,
+            root: 0,
+        },
+        Commitment::Confirmed,
+    );
 
-    // assert_eq!(
-    //     token_store.process_slot_data(
-    //         SlotInfo {
-    //             slot: 3,
-    //             parent: 2,
-    //             root: 0,
-    //         },
-    //         Commitment::Finalized
-    //     ),
-    //     vec![token_account_data_2.clone()]
-    // );
+    token_store.process_slot_data(
+        SlotInfo {
+            slot: 3,
+            parent: 2,
+            root: 0,
+        },
+        Commitment::Finalized,
+    );
 
     let mint_2 = utils::MintCreationParams::create_random(&mut rng, 2000);
 
@@ -392,19 +377,16 @@ pub fn test_saving_and_loading_token_account() {
         token_account_params_2
     );
 
-    assert_eq!(
-        token_store.process_slot_data(
-            SlotInfo {
-                slot: 6,
-                parent: 5,
-                root: 0,
-            },
-            Commitment::Confirmed
-        ),
-        vec![]
+    token_store.process_slot_data(
+        SlotInfo {
+            slot: 6,
+            parent: 5,
+            root: 0,
+        },
+        Commitment::Confirmed,
     );
 
-    let accounts_updated = token_store.process_slot_data(
+    token_store.process_slot_data(
         SlotInfo {
             slot: 5,
             parent: 4,
@@ -412,11 +394,6 @@ pub fn test_saving_and_loading_token_account() {
         },
         Commitment::Finalized,
     );
-
-    // assert!(
-    //     accounts_updated == vec![mint_account_2.clone(), account_data_3.clone()]
-    //         || accounts_updated == vec![account_data_3.clone(), mint_account_2.clone()]
-    // );
 
     assert_eq!(
         token_store
@@ -450,16 +427,13 @@ pub fn test_saving_and_loading_token_account() {
         token_account_params_3
     );
 
-    assert_eq!(
-        token_store.process_slot_data(
-            SlotInfo {
-                slot: 6,
-                parent: 5,
-                root: 0,
-            },
-            Commitment::Finalized
-        ),
-        vec![]
+    token_store.process_slot_data(
+        SlotInfo {
+            slot: 6,
+            parent: 5,
+            root: 0,
+        },
+        Commitment::Finalized,
     );
 
     assert_eq!(

--- a/token_account_storage/tests/utils.rs
+++ b/token_account_storage/tests/utils.rs
@@ -1,4 +1,4 @@
-use lite_account_manager_common::account_data::{Account, AccountData};
+use lite_account_manager_common::account_data::{Account, AccountData, Data};
 use lite_token_account_storage::account_types::TokenProgramAccountState;
 use rand::{rngs::ThreadRng, Rng};
 use solana_sdk::{clock::Slot, program_option::COption, program_pack::Pack, pubkey::Pubkey};
@@ -117,9 +117,7 @@ pub fn create_token_account_data(
         pubkey,
         account: Arc::new(Account {
             lamports: 2039280,
-            data: lite_account_manager_common::account_data::Data::Uncompressed(
-                create_token_account(token_creation_params),
-            ),
+            data: Data::Uncompressed(create_token_account(token_creation_params)),
             owner: spl_token::id(),
             executable: false,
             rent_epoch: u64::MAX,
@@ -142,10 +140,8 @@ pub fn parse_account_data_to_token_params(account_data: AccountData) -> TokenAcc
     let token_account =
         spl_token::state::Account::unpack(&account_data.account.data.data()).unwrap();
     let delegate = match token_account.delegate {
-        solana_sdk::program_option::COption::Some(delegate) => {
-            Some((delegate, token_account.delegated_amount))
-        }
-        solana_sdk::program_option::COption::None => Option::None::<_>,
+        COption::Some(delegate) => Some((delegate, token_account.delegated_amount)),
+        COption::None => None,
     };
     TokenAccountParams {
         owner: token_account.owner,
@@ -181,9 +177,7 @@ pub fn create_mint_account_data(
         pubkey,
         account: Arc::new(Account {
             lamports: 1000,
-            data: lite_account_manager_common::account_data::Data::Uncompressed(create_mint(
-                mint_creation_params,
-            )),
+            data: Data::Uncompressed(create_mint(mint_creation_params)),
             owner: spl_token::id(),
             executable: false,
             rent_epoch: u64::MAX,


### PR DESCRIPTION
When importing an old snapshot and then receiving updates via GRPC/Quick, the `process_slot_data` method could panic in the `InmemoryTokenStorage` implementation for token accounts because the return value required a data conversion to `AccountData` which in turn needs the a mint account to be available for a token account. After importing an old snapshot and receiving token account updates via GRPC, there can be a window of slots that was never imported and thus mint accounts can be missing for updated token accounts while the DB is catching up to the cluster state.